### PR TITLE
Update GPT3 workload to nccl v1.0.3, rxdm v1.0.9, and nemo 24.07

### DIFF
--- a/Training/A3Mega/GPT3-175B-NeMo/docker/nemo_example.Dockerfile
+++ b/Training/A3Mega/GPT3-175B-NeMo/docker/nemo_example.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/nemo:24.05
+FROM nvcr.io/nvidia/nemo:24.07
 WORKDIR /workspace
 
 # GCSfuse components (used to provide shared storage, not intended for high performance)

--- a/Training/A3Mega/GPT3-175B-NeMo/helm-context/templates/nemo-example.yaml
+++ b/Training/A3Mega/GPT3-175B-NeMo/helm-context/templates/nemo-example.yaml
@@ -328,6 +328,8 @@ spec:
         value: "libnccl-tuner.so"
       - name: NCCL_TUNER_CONFIG_PATH
         value: "/usr/local/nccl-plugin/lib64/a3plus_tuner_config.textproto"
+      - name: NCCL_SHIMNET_GUEST_CONFIG_CHECKER_CONFIG_FILE
+        value: "/usr/local/nccl-plugin/lib64/a3plus_guest_config.textproto"
    
       {{ end }}
 

--- a/Training/A3Mega/GPT3-175B-NeMo/helm-context/values.yaml
+++ b/Training/A3Mega/GPT3-175B-NeMo/helm-context/values.yaml
@@ -37,8 +37,8 @@ workload:
 network:
   stack: "tcpxo" # one of {"tcp", "tcpx", "tcpxo"}
 
-  daemonVersion: "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.8"
-  pluginVersion: "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.1"
+  daemonVersion: "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/tcpgpudmarxd-dev:v1.0.9"
+  pluginVersion: "us-docker.pkg.dev/gce-ai-infra/gpudirect-tcpxo/nccl-plugin-gpudirecttcpx-dev:v1.0.3"
     
 
   ncclSettings:


### PR DESCRIPTION
nemo 24.05 ➡️ 24.07
nccl 1.0.1 ➡️ 1.0.3
rxdm 1.0.8 ➡️ 1.0.9