### PR TITLE
Update Mixtral reproducibility instructions

### DIFF
--- a/Training/TPU-v5p/Mixtral-8x7B-PyTorch/README.md
+++ b/Training/TPU-v5p/Mixtral-8x7B-PyTorch/README.md
@@ -1,5 +1,4 @@
-# Instructions for training  Mixtral-8X7B on TPU v5p
-
+# Instructions for training Mixtral-8X7B on TPU v5p
 
 
 This user guide provides a concise overview of the essential steps required to run HuggingFace (HF) Mixtral training on Cloud TPUs.
@@ -7,132 +6,37 @@ This user guide provides a concise overview of the essential steps required to r
 
 ## Environment Setup
 
-Please follow the corresponding TPU generation's user guide to setup the GCE TPUs first.
-### Setup Environment of Your TPUs
+Please follow the corresponding TPU generation's user guide to setup the GCE TPUs
+first.
+
+NOTE: For best performance on Mixtral, use "untwisted" variants of TPU topologies.
+For example, if you're creating a 128 chip v5p slice, select `4x4x8_untwisted` in
+the `gcloud` CLI. The default is "twisted" which has been observed to reduce
+performance in Mixtral. See [1] about details on twisted tori.
+
 Please replace all your-* with your TPUs' information.
+
 ```
 export TPU_NAME=your-tpu-name
 export ZONE=your-tpu-zone
 export PROJECT=your-tpu-project
 ```
 
-### HF Mixtral 7 x 8B Environment Setup (without docker)
-
-<details>
-
-<summary>Click to see how to setup environment and run without docker</summary>
-
-The following setup assumes to run the training job with Mixtral 7 x 8B on GCE TPUs. Please follow corresponding TPU generation's user guide to setup the GCE TPUs. For GKE users, most of the commands below also apply.
-
-Here both PyTorch and PyTorch/XLA nightly are used with our fork of HuggingFace.
-```
-gcloud alpha compute tpus tpu-vm ssh ${TPU_NAME} \
---zone ${ZONE} \
---project ${PROJECT} \
---worker=all \
---command='
-# Step 1: install torch, torch-xla, libtpu, pallas
-pip3 install --pre torch --index-url https://download.pytorch.org/whl/nightly/cpu
-pip3 install https://storage.googleapis.com/pytorch-xla-releases/wheels/tpuvm/torch_xla-nightly-cp310-cp310-linux_x86_64.whl
-pip3 install torch_xla[tpu] -f https://storage.googleapis.com/libtpu-releases/index.html
-pip3 install torch_xla[pallas] -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_releases.html
-
-# Step 2: install HF
-git clone -b alanwaketan/moe https://github.com/pytorch-tpu/transformers.git
-cd transformers
-pip3 install git+file://$PWD
-pip3 install accelerate datasets evaluate scikit-learn huggingface-hub
-'
-```
-
-The next step is to sign into HF such that you can get accesses to the tokenizer or model checkpoints. Please replace `your_token` with your HF token.
-```
-gcloud alpha compute tpus tpu-vm ssh ${TPU_NAME} \
---zone ${ZONE} \
---project ${PROJECT} \
---worker=all \
---command='
-export PATH=$PATH:/home/$USER/.local/bin
-huggingface-cli login --token your_token
-'
-```
-
-The next step for HF setup is to copy your [Mixtral config](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1) into the TPU VM.
-```
-gcloud compute tpus tpu-vm scp mixtral87.json $TPU_NAME:~/config.json --worker all --project $PROJECT --zone=$ZONE
-```
-
-The last step for HF setup is to copy your fsdp_config.json into the TPU VM.
-```
-{
-    "fsdp_transformer_layer_cls_to_wrap": [
-        "MixtralDecoderLayer"
-    ],
-    "xla": true,
-    "xla_fsdp_v2": true,
-    "xla_fsdp_grad_ckpt": true
-}
+You may use this command to create an untwisted 128 chip v5p slice:
 
 ```
-And the command to copy the config.
+gcloud alpha compute tpus tpu-vm create $TPU_NAME \
+    --type v5p --topology 4x4x8_untwisted \
+    --project $PROJECT --zone $ZONE --version v2-alpha-tpuv5
 ```
-gcloud compute tpus tpu-vm scp fsdp_config.json $TPU_NAME:~/fsdp_config.json --worker all --project $PROJECT --zone=$ZONE
-```
 
-## Steps to Run HF Mixtral 8 x 7B
-Following is the gcloud ssh command to run the training job from the host:
-```
-gcloud alpha compute tpus tpu-vm ssh ${TPU_NAME} \
---zone ${ZONE} \
---project ${PROJECT} \
---worker=all \
---command='
-# Setup envs
-export PJRT_DEVICE=TPU
-export XLA_USE_SPMD=1
-export XLA_IR_DEBUG=1
-export XLA_HLO_DEBUG=1
+## Steps to Run HF Mixtral 8x7B
 
-export PROFILE_EPOCH=0
-export PROFILE_STEP=3
-export PROFILE_DURATION_MS=20000
-export PROFILE_LOGDIR=/tmp/home/
-
-# Run
-cd transformers
-python3 examples/pytorch/language-modeling/run_clm.py \
-  --dataset_name wikitext \
-  --dataset_config_name wikitext-2-raw-v1 \
-  --per_device_train_batch_size 32 \
-  --do_train \
-  --output_dir /tmp/test-clm \
-  --overwrite_output_dir \
-  --config_name ~/config.json \
-  --cache_dir /tmp \
-  --tokenizer_name mistralai/Mixtral-8x7B-v0.1 \
-  --block_size 4096 \
-  --optim adafactor \
-  --save_strategy no \
-  --logging_strategy no \
-  --fsdp "full_shard" \
-  --fsdp_config ~/fsdp_config.json \
-  --torch_dtype bfloat16 \
-  --dataloader_drop_last yes \
-  --flash_attention \
-  --max_steps 10 \
-  --gmm
-
-```
-</details>  
-
-------  
-### HF Mixtral 7 x 8B Environment Setup (with docker)
-
-The following setup assumes to run the training job with Mixtral 7 x 8B on GCE TPUs using the docker image from this registery (`us-central1-docker.pkg.dev/tpu-pytorch/docker/reproducibility/mixtral@sha256:1e9024d13e53bdadc13d7a695d8fbe52b95a78cfae2a101da8a9d8fc94b1c96b`), the docker image uses the pytorch and torch_xla nightly build from 09/16/2024 and installed with all the package dependency needed to run the model training. All the command below should run from your own machine (not the TPU host you created).
+The following setup runs the training job with Mixtral 8x7B on GCE TPUs using the docker image from this registry (`us-central1-docker.pkg.dev/tpu-pytorch/docker/reproducibility/mixtral@sha256:c8f4a66e02a26548c9d71296cd345d3a302f6960db3da7fd3addf34c00332b5b`), the docker image uses the pytorch and torch_xla nightly build from 09/28/2024 and installed with all the package dependency needed to run the model training. All the command below should run from your own machine (not the TPU host you created).
 
 1. git clone and navigate to this README repo and run training script:
 ```bash
-git clone  --depth 1 https://github.com/gclouduniverse/reproducibility.git
+git clone --depth 1 https://github.com/gclouduniverse/reproducibility.git
 cd reproducibility/Training/TPU-v5p/Mixtral-8x7B-PyTorch
 ```
 2. Edit `env.sh` to add the hugging face token and/or setup the training parameters.
@@ -143,11 +47,11 @@ HF_TOKEN=hf_***
 3. Edit `host.sh` to add the docker image URL if default docker image is not accessible to you.
 ```bash
 # docker image URL to use for the training
-DOCKER_IMAGE=us-central1-docker.pkg.dev/tpu-pytorch/docker/reproducibility/mixtral@sha256:1e9024d13e53bdadc13d7a695d8fbe52b95a78cfae2a101da8a9d8fc94b1c96b
+DOCKER_IMAGE=us-central1-docker.pkg.dev/tpu-pytorch/docker/reproducibility/mixtral@sha256:c8f4a66e02a26548c9d71296cd345d3a302f6960db3da7fd3addf34c00332b5b
 ```
 4. Run the training script:
 ```bash
-bash benchmark.sh
+./benchmark.sh
 ```
 `benchmark.sh` script will upload 1) environment parameters in `env.sh`, 2) model related config in `config.json`, `fsdp_config.json`, 3) docker launch script in `host.sh` and 4) python training command in `train.sh` into all TPU workers, and starts the training afterwards. When all training steps complete, it will print out training metrics of each worker as below in terminal:
 ```
@@ -155,9 +59,14 @@ bash benchmark.sh
 [worker :0]   epoch                    =        0.3125
 [worker :0]   total_flos               = 10915247040GF
 [worker :0]   train_loss               =         9.278
-[worker:0]   train_runtime            =    0:46:45.60
+[worker :0]   train_runtime            =    0:46:45.60
 [worker :0]   train_samples            =         32816
 [worker :0]   train_samples_per_second =          3.65
 [worker :0]   train_steps_per_second   =         0.007
 ```
-In addition,  it will copy back the trained model under *output/*.
+In addition,  it will copy back the trained model under `output/*`.
+
+<!-- xrefs -->
+
+[1]: https://cloud.google.com/tpu/docs/v4#twisted-tori
+

--- a/Training/TPU-v5p/Mixtral-8x7B-PyTorch/benchmark.sh
+++ b/Training/TPU-v5p/Mixtral-8x7B-PyTorch/benchmark.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+
 # SCP the environment setup to all instances.
-gcloud compute tpus tpu-vm scp config.json fsdp_config.json train.sh host.sh env.sh $TPU_NAME:~ --worker=all --project $PROJECT --zone=$ZONE
+gcloud compute tpus tpu-vm scp config.json fsdp_config.json train.sh host.sh env.sh "$TPU_NAME:~" --worker=all --project $PROJECT --zone=$ZONE
 
 # Actually runs the benchmark.
 gcloud compute tpus tpu-vm ssh $TPU_NAME --project $PROJECT --zone=$ZONE --worker=all --command="$(cat host.sh)"

--- a/Training/TPU-v5p/Mixtral-8x7B-PyTorch/config.json
+++ b/Training/TPU-v5p/Mixtral-8x7B-PyTorch/config.json
@@ -11,9 +11,9 @@
     "intermediate_size": 14336,
     "max_position_embeddings": 32768,
     "model_type": "mixtral",
-    "num_attention_heads": 32, 
+    "num_attention_heads": 32,
     "num_experts_per_tok": 2,
-    "num_hidden_layers": 32, 
+    "num_hidden_layers": 32,
     "num_key_value_heads": 8,
     "num_local_experts": 8,
     "output_router_logits": false,
@@ -24,7 +24,7 @@
     "tie_word_embeddings": false,
     "torch_dtype": "bfloat16",
     "transformers_version": "4.36.0.dev0",
-    "use_cache": true,
+    "use_cache": false,
     "vocab_size": 32000
 }
 

--- a/Training/TPU-v5p/Mixtral-8x7B-PyTorch/env.sh
+++ b/Training/TPU-v5p/Mixtral-8x7B-PyTorch/env.sh
@@ -15,3 +15,6 @@ SEQ_LENGTH=4096
 # since each TPU VM is connected to 4 v5p TPU chips. The following will lead
 # to a per-device batch size of 8. Customize accordingly.
 PER_HOST_BATCH_SIZE=32
+
+# XLA flags
+LIBTPU_INIT_ARGS='--xla_enable_async_collective_permute=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_rwb_fusion=false --xla_jf_rematerialization_percent_shared_memory_limit=10000 --xla_tpu_enable_net_router_in_all_gather=false --xla_tpu_prefer_async_allgather_to_allreduce=true --xla_enable_all_gather_3d_emitter=true'

--- a/Training/TPU-v5p/Mixtral-8x7B-PyTorch/env.sh
+++ b/Training/TPU-v5p/Mixtral-8x7B-PyTorch/env.sh
@@ -9,4 +9,9 @@ PROFILE_DURATION_MS=120000
 XLA_USE_SPMD=1
 MAX_STEPS=20
 SEQ_LENGTH=4096
-BATCH_SIZE=512
+
+# Per-host batch size is the number of training examples used by a TPU VM
+# in each training step. For v5p, it will be 4 times the per-device batch size,
+# since each TPU VM is connected to 4 v5p TPU chips. The following will lead
+# to a per-device batch size of 8. Customize accordingly.
+PER_HOST_BATCH_SIZE=32

--- a/Training/TPU-v5p/Mixtral-8x7B-PyTorch/host.sh
+++ b/Training/TPU-v5p/Mixtral-8x7B-PyTorch/host.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DOCKER_IMAGE=us-central1-docker.pkg.dev/tpu-pytorch/docker/reproducibility/mixtral@sha256:1e9024d13e53bdadc13d7a695d8fbe52b95a78cfae2a101da8a9d8fc94b1c96b
+DOCKER_IMAGE=us-central1-docker.pkg.dev/tpu-pytorch/docker/reproducibility/mixtral@sha256:c8f4a66e02a26548c9d71296cd345d3a302f6960db3da7fd3addf34c00332b5b
 
 worker_id=$(curl -s "http://metadata.google.internal/computeMetadata/v1/instance/attributes/agent-worker-number" -H 'Metadata-Flavor: Google')
 

--- a/Training/TPU-v5p/Mixtral-8x7B-PyTorch/train.sh
+++ b/Training/TPU-v5p/Mixtral-8x7B-PyTorch/train.sh
@@ -17,7 +17,7 @@ cd transformers/
 python3 examples/pytorch/language-modeling/run_clm.py \
   --dataset_name wikitext \
   --dataset_config_name wikitext-103-raw-v1 \
-  --per_device_train_batch_size "${BATCH_SIZE}" \
+  --per_device_train_batch_size "${PER_HOST_BATCH_SIZE}" \
   --do_train \
   --output_dir "${LOCAL_DIR}/output/test-clm" \
   --overwrite_output_dir \


### PR DESCRIPTION
Link to a new docker image.

I deleted the instructions that does not use docker. Without a docker image capturing the dependencies, performance will inevitably change and we cannot ensure reproducibility.

Update train.sh to pass per host batch size to Hugging Face.

Mention the recommendation of using untwisted TPU topologies.