### PR TITLE
Fix instruction for serving trillium Mixtral 8x22B model

### DIFF
--- a/Serving/Trillium/JetStream-Maxtext/Mixtral-8X22B/README.md
+++ b/Serving/Trillium/JetStream-Maxtext/Mixtral-8X22B/README.md
@@ -63,7 +63,8 @@ python MaxText/maxengine_server.py \
   scan_layers=${SCAN_LAYERS} \
   weight_dtype=${WEIGHT_DTYPE} \
   per_device_batch_size=${PER_DEVICE_BATCH_SIZE} \
-  megablox=False capacity_factor=-1 \ 
+  megablox=False \
+  capacity_factor=-1 \
   quantization=int8 checkpoint_is_quantized=True \
   quantize_kvcache=True
 ```


### PR DESCRIPTION
Remove the extra space that cause command errors when copying.